### PR TITLE
feat: add --exclude flag for filtering files by glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Fast parallel downloader for HuggingFace repositories using aria2c.
 
 # Interactive file selection
 ./hf.sh Qwen/Qwen2.5-0.5B -i
+
+# Exclude specific file patterns
+./hf.sh Qwen/Qwen2.5-0.5B --exclude "*.sh,*.md,*.yaml"
 ```
 
 ## Options
@@ -37,6 +40,7 @@ Fast parallel downloader for HuggingFace repositories using aria2c.
 - `--console-log-level <lvl>` - Console log level (default: error)
 - `--download-result <res>` - Download result (default: full)
 - `--summary-interval <sec>` - Summary interval (default: 10)
+- `--exclude <patterns>` - Comma-separated glob patterns to exclude files (e.g., *.sh,*.md,*.yaml)
 - `--token <token>` - HuggingFace token for private repos
 - `-h, --help` - Show help
 


### PR DESCRIPTION
- Add --exclude option to filter out files matching glob patterns
- Support comma-separated patterns (e.g., *.sh,*.md,*.yaml)
- Update README with usage examples and documentation

Closes #2 